### PR TITLE
Update main.yml - remove deprecated include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,13 +2,13 @@
 # Main task
 
 - name: Install ROS2
-  include: ros2-install.yml
+  include_tasks: ros2-install.yml
   tags: ros2-install
 
 - name: ROS2 Workspace Setup
-  include: ros2-workspace-setup.yml
+  include_tasks: ros2-workspace-setup.yml
   tags: ros2-workspace-setup
 
 - name: ROS2 Packages Install
-  include: ros2-packages-install.yml
+  include_tasks: ros2-packages-install.yml
   tags: ros2-packages-install


### PR DESCRIPTION
On newer ansible versions, there is a deprecation warning

> ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

This PR fixes this